### PR TITLE
Add HymnalPurchasedList component to display purchased books

### DIFF
--- a/lib/definitions/data.ts
+++ b/lib/definitions/data.ts
@@ -6,3 +6,7 @@ export const hymnalNames: string[] = [
     "Worship The King",
     "Primitive Baptist Hymnal"
 ]
+
+export interface HymnalAccessData {
+    [hymnalName: string]: boolean;
+  }

--- a/lib/definitions/props.ts
+++ b/lib/definitions/props.ts
@@ -22,3 +22,7 @@ export type PayPalWrapperProps = {
   book: string;
   user: User | null | undefined;
 }
+
+export type GenericAuthProps = {
+  user: User | null | undefined;
+}

--- a/lib/firebase-functions.ts
+++ b/lib/firebase-functions.ts
@@ -1,10 +1,10 @@
 import { getDocs, collection, doc, getDoc, setDoc, DocumentData } from 'firebase/firestore';
 import { auth, firestore } from './firebase';
 import { BookProps } from '@definitions/props';
-import { hymnalNames } from '@definitions/data';
+import { hymnalNames, HymnalAccessData } from '@definitions/data';
 import { User } from 'firebase/auth';
 
-export async function unlockSelectedHymnal(bookTitle: string, user: User | null | undefined, ) {
+export async function unlockSelectedHymnal(bookTitle: string, user: User | null | undefined,) {
     /* aquire user id */
     if (user?.email) {
         console.log(user.email)
@@ -27,7 +27,7 @@ export async function unlockSelectedHymnal(bookTitle: string, user: User | null 
     }
 }
 
-export async function lockSelectedHymnals(hymnals: BookProps[], user: User | null, ) {
+export async function lockSelectedHymnals(hymnals: BookProps[], user: User | null,) {
     /* aquire user id */
     if (user?.email != null) {
 
@@ -47,6 +47,26 @@ export async function lockSelectedHymnals(hymnals: BookProps[], user: User | nul
             console.log("No such document!");
         }
     }
+}
+
+export async function getBookPurchases(user: User | null | undefined): Promise<{ title: string, purchased: boolean }[]> {
+    if (user?.email) {
+
+        const docRef = doc(firestore, "users", user.email.toString(), "userData", "hymnalAccess");
+        const docSnap = await getDoc(docRef);
+
+        if (!docSnap.exists()) {
+            return [];
+        }
+
+        const hymnalAccessData = docSnap.data() as HymnalAccessData;
+
+        return hymnalNames.map(hymnalName => ({
+            title: hymnalName,
+            purchased: hymnalAccessData[getMappingBetweenHymnals(hymnalName)] ?? false
+        }));
+    }
+    return [];
 }
 
 /* Helper Functions */

--- a/src/components/AccountInfo.tsx
+++ b/src/components/AccountInfo.tsx
@@ -2,13 +2,14 @@ import { logout } from "@lib/helpers";
 import React, { useContext } from "react";
 import { UserContext } from "@lib/context";
 import styles from "../styles/components/AccountInfo.module.scss";
-
+import HymnalPuchasedList from "@components/HymnalPurchasedList";
 
 const AccountInfo = () => {
   const { user, username } = useContext(UserContext)
   return (
     <div className={styles.accountInfoContainer}>
-      <h2>Hi {username}, purchase info will eventually be added to this section.</h2>
+      <h2>Hi {username}, here are the books and purchases.</h2>
+      <HymnalPuchasedList user={user} />
       <button onClick={() => logout()}>Log out</button>
     </div>
   );

--- a/src/components/HymnalPurchasedList.tsx
+++ b/src/components/HymnalPurchasedList.tsx
@@ -1,0 +1,26 @@
+import { useState, useEffect } from 'react';
+import { getBookPurchases } from '@lib/firebase-functions';
+import { GenericAuthProps } from '@lib/definitions/props';
+
+export default function HymnalList(props: GenericAuthProps) {
+  const [bookPurchases, setBookPurchases] = useState<{ title: string, purchased: boolean }[]>([]);
+
+  useEffect(() => {
+    async function fetchBookPurchases() {
+      const purchases = await getBookPurchases(props.user);
+      setBookPurchases(purchases);
+    }
+
+    fetchBookPurchases();
+  }, [props.user]);
+
+  return (
+    <ul>
+      {bookPurchases.map(book => (
+        <li key={book.title}>
+          {book.title} - {book.purchased ? 'Purchased' : 'Not Purchased'}
+        </li>
+      ))}
+    </ul>
+  );
+}


### PR DESCRIPTION
This commit adds a new component called HymnalPurchasedList that displays the list of books and their purchase status. The getBookPurchases function is added to firebase-functions.ts to retrieve the data from Firestore. The AccountInfo component in AccountInfo.tsx is updated to include the new HymnalPurchasedList component. Additionally, some changes are made in definitions/data.ts and definitions/props.ts files by adding a new interface for hymnals access data and generic authentication props respectively.